### PR TITLE
파일 업로드시, 디렉토리도 도큐먼트를 만들도록 구현함

### DIFF
--- a/backend/src/model/cloud.ts
+++ b/backend/src/model/cloud.ts
@@ -19,6 +19,7 @@ const cloudSchema: Schema<ICloudDoc> = new Schema(
 	{
 		osLink: {
 			type: String,
+			default: '',
 		},
 		directory: {
 			type: String,


### PR DESCRIPTION
파일을 업로드할 시, 해당 파일이 포함되는 폴더들 역시 도큐먼트로 만듬

만약 `/folder1/folder2/test.txt`를 업로드하였을 때 만들어지는 도큐먼트들은 다음과 같다.
``` json
{
  directory: '/',
  name: 'folder1',
  ...
},
{
  directory: '/folder1',
  name: 'folder2',
  ...
},
{
  directory: '/folder1/folder2',
  name: 'test.txt',
  ...
},
```
